### PR TITLE
Fix go runtime version error

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -5,13 +5,6 @@
       "GO_BUILD_FLAGS": "-ldflags '-s -w'"
     }
   },
-  "functions": {
-    "api/index.go": {
-      "maxDuration": 300,
-      "memory": 1024,
-      "runtime": "go1.x"
-    }
-  },
   "routes": [
     { "src": "(?:.*)", "dest": "api/index.go" }
   ]


### PR DESCRIPTION
Remove `functions` section from `vercel.json` to fix 'Function Runtimes must have a valid version' error.

The previous `vercel.json` configuration included `"runtime": "go1.x"` which is an invalid format for Vercel Go functions. Reverting to a simpler configuration by removing the `functions` section allows Vercel to automatically detect the Go runtime from `go.mod`, resolving the build error. This configuration matches a previously working deployment.

---

[Open in Web](https://www.cursor.com/agents%3Fid=bc-c3ed46e6-975d-4d4d-9678-9b5a3b76788a) • [Open in Cursor](https://cursor.com/background-agent%3FbcId=bc-c3ed46e6-975d-4d4d-9678-9b5a3b76788a)